### PR TITLE
Added OIDC instead of token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [codeql]  # Only depends on CodeQL (which depends on test + coverage)
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    environment: npm
     permissions:
       contents: write
       issues: write
@@ -173,7 +174,6 @@ jobs:
     - name: Semantic Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         NPM_CONFIG_PROVENANCE: true
       run: npx semantic-release
 


### PR DESCRIPTION
Release to npm.js is no longer token based but uses OIDC instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release authentication path in CI; misconfiguration of OIDC/environment settings could block or misdirect publishes even though no runtime code changes are involved.
> 
> **Overview**
> Switches the npm publish workflow to use GitHub OIDC for authentication instead of an `NPM_TOKEN` secret.
> 
> The `publish` job now targets the `npm` environment and drops `NODE_AUTH_TOKEN` from the `semantic-release` step while keeping `id-token: write` permissions and provenance enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bd1734f2a95570503d35f8ea19d0a8bf58090a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->